### PR TITLE
Add a line to auto update belgian bank codes

### DIFF
--- a/data/update-data.sh
+++ b/data/update-data.sh
@@ -3,4 +3,5 @@
 curl https://www.oenb.at/docroot/downloads_observ/sepa-zv-vz_gesamt.csv | iconv -f ISO-8859-1 -t UTF-8 > at.csv
 curl -L https://www.bundesbank.de/resource/blob/602632/de8bc9ff83a50360ade75055734724aa/mL/blz-aktuell-txt-data.txt | iconv -f ISO-8859-1 -t UTF-8 > bundesbank.txt
 curl https://api.six-group.com/api/epcd/bankmaster/v2/public/downloads/bcbankenstamm_d.xls -o ch.xls && libreoffice --convert-to xlsx ch.xls --headless
+curl https://www.nbb.be/doc/be/be/protocol/current_codes.xlsx -o nbb.xlsx
  


### PR DESCRIPTION
Following link in your /data/sources.txt I've added a line to auto update the belgian bank codes. The one in the repo is a version of 2019.